### PR TITLE
Initial Template example for Harness CI Image Factory

### DIFF
--- a/harness-ci-factory/Makefile
+++ b/harness-ci-factory/Makefile
@@ -1,0 +1,18 @@
+# Makefile
+# Standard top-level shared Makefile switchboard to consolidate all common
+# rules which will be used when testing or executing this repository.
+#
+
+PROJECT_DIR=${PWD}/../
+TEMPLATE_DIR=$(notdir $(shell pwd))
+
+# Auto-include the repository root Makefile to access shared resources
+ifneq ("$(wildcard ../Makefile)", "")
+	include ../Makefile
+endif
+ifneq ("$(wildcard ../Makefile.local)", "")
+	include ../Makefile.local
+endif
+ifneq ("$(wildcard Makefile.local)", "")
+	include Makefile.local
+endif

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -1,4 +1,5 @@
 # Harness CI Image Factory
+
 A collection of Terraform resources centered around the implementation of the Harness CI Factory Pipeline to support managing Harness CI Container Images
 
 ## TLDR
@@ -26,6 +27,7 @@ module "harness-ci-factory" {
 After pulling, building, and pushing the images to your registry you will need to edit the `harnessImage` docker connector in your Harness account to point that the registry you pushed to using this module (specified by the `container_registry` input).
 
 ## Summary
+
 As the Harness Solutions Architecture team, we have developed a pipeline to manage the ingestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
 
 - An optional new Harness Organization
@@ -39,9 +41,11 @@ _Note: The created pipeline has a built-in retry mechanism which will automatica
 
 
 ## Providers
+
 This module requires that the calling template has defined the [Harness Provider - Docs](https://registry.terraform.io/providers/harness/harness/latest/docs) authentication.
 
 ### Example setup of the Harness Provider Authentication with environment variables
+
 You can also set up authentication with Harness through environment variables. To do this set the following items in your environment:
 - HARNESS_ACCOUNT_ID: Harness Platform Account Number
 - HARNESS_PLATFORM_API_KEY: Harness Platform API Key for your account
@@ -49,6 +53,7 @@ You can also set up authentication with Harness through environment variables. T
 _Note: The use of the HARNESS_ENDPOINT environment variable is not used as the variable `harness_platform_url` is a required input for some of the resource creation steps and cannot be read within the execution except by explicit declaration of the variables value_
 
 ### Example setup of the Harness Provider
+
 ```
 # Provider Setup Details
 variable "harness_platform_url" {
@@ -80,6 +85,7 @@ provider "harness" {
 ```
 
 ### Terraform required providers declaration
+
 ```
 terraform {
   required_providers {
@@ -97,6 +103,7 @@ terraform {
 ```
 
 ## Requirements
+
 The following items will be required to be preconfigured in our Harness Account
 - Harness Service Account with an API Key
 - Kubernetes Connector with a chosen namespace for execution of the Build Pods
@@ -109,8 +116,6 @@ _Note: When providing `_ref` values, please ensure that these are prefixed with 
 | Name | Description | Type | Default Value | Mandatory |
 | --- | --- | --- | --- | --- |
 | harness_platform_url | Enter the Harness Platform URL.  Defaults to Harness SaaS URL | string | https://app.harness.io/gateway | X |
-| harness_platform_account | Enter the Harness Platform Account Number | string | null | X |
-| harness_platform_key | Enter the Harness Platform API Key for your account | string | null | X |
 | harness_api_key_secret | Enter the Harness secret that holds an API key for your account | string | | X |
 | organization_name | Provide an organization name.  Must be two or more characters | string | | X |
 | create_organization | Should this execution create a new Organization | bool | false | X |
@@ -126,22 +131,25 @@ _Note: When providing `_ref` values, please ensure that these are prefixed with 
 | schedule | Cron Format schedule for when and how frequently to schedule this pipeline | string | "0 2 * * *" | |
 
 
-
 ## Terraform TFVARS
+
 Included in this repository is a `terraform.tfvars.example` file with a sample file that can be used to construct your own `terraform.tfvars` file.
 
 - Save a copy of the file as `terraform.tfvars`
 - Update the variable values listed in the new TFVAR file
 
 ## Outputs
+
 | Name | Description | Value |
 | --- | --- | --- |
 | pipeline | Details for the created Harness pipeline | Map containing details of created pipeline |
 
 ## Contributing
+
 A complete [Contributors Guide](../CONTRIBUTING.md) can be found in this repository
 
 ## Authors
+
 Module is maintained by Harness, Inc
 
 ## License

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -23,6 +23,8 @@ module "harness-ci-factory" {
 }
 ```
 
+After pulling, building, and pushing the images to your registry you will need to edit the `harnessImage` docker connector in your Harness account to point that the registry you pushed to using this module (specified by the `container_registry` input).
+
 ## Summary
 As the Harness Solutions Architecture team, we have developed a pipeline to manage the ingestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
 

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -1,0 +1,127 @@
+# Harness CI Image Factory
+A collection of Terraform resources centered around the implementation of the Harness CI Factory Pipeline to support managing Harness CI Container Images
+
+## Goal
+TODO
+
+## Summary
+As the Harness Solutions Architecture team, we have developed a pipeline to manage the injestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
+
+- An optional new Harness Organization
+- An optional new Harness Project in the chosen Organization
+- A new Stage Template designed to retrieve and compare the list of images to generate a new list from which to build
+- A new Stage Template designed to create a pass-thru Dockerfile and push to the chose `container_registry_type`
+- A new Pipeline used to collect, build, and push the Harness CI images into the selected container registry
+- A new Pipeline trigger to schedule the repeated execution of the Pipeline
+
+_Note: The created pipeline has a built-in retry mechanism which will automatically retrigger the pipeline.  This execution is designed to only run once and will automatically invoke the execution at the end of the run when it is determined that not all the images updated successfully._
+
+
+## Providers
+This module requires that the calling template has defined the [Harness Provider - Docs](https://registry.terraform.io/providers/harness/harness/latest/docs) authentication.
+
+### Example setup of the Harness Provider Authentication with environment variables
+You can also set up authentication with Harness through environment variables. To do this set the following items in your environment:
+- HARNESS_ACCOUNT_ID: Harness Platform Account Number
+- HARNESS_PLATFORM_API_KEY: Harness Platform API Key for your account
+
+_Note: The use of the HARNESS_ENDPOINT environment variable is not used as the variable `harness_platform_url` is a required input for some of the resource creation steps and cannot be read within the execution except by explicit declaration of the variables value_
+
+### Example setup of the Harness Provider
+```
+# Provider Setup Details
+variable "harness_platform_url" {
+  type        = string
+  description = "[Optional] Enter the Harness Platform URL.  Defaults to Harness SaaS URL"
+  default     = "https://app.harness.io/gateway"
+}
+
+variable "harness_platform_account" {
+  type        = string
+  description = "[Required] Enter the Harness Platform Account Number"
+  default     = null # If Not passed, then the ENV HARNESS_ACCOUNT_ID will be used
+  sensitive   = true
+}
+
+variable "harness_platform_key" {
+  type        = string
+  description = "[Required] Enter the Harness Platform API Key for your account"
+  default     = null # If Not passed, then the ENV HARNESS_PLATFORM_API_KEY will be used
+  sensitive   = true
+}
+
+provider "harness" {
+  endpoint         = var.harness_platform_url
+  account_id       = var.harness_platform_account
+  platform_api_key = var.harness_platform_key
+}
+
+```
+
+### Terraform required providers declaration
+```
+terraform {
+  required_providers {
+    harness = {
+      source  = "harness/harness"
+      version = ">= 0.14"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9.1"
+    }
+  }
+}
+
+```
+
+## Requirements
+The following items will be required to be preconfigured in our Harness Account
+- Harness Service Account with an API Key
+- Kubernetes Connector with a chosen namespace for execution of the Build Pods
+- Container Registry Connector of a supported type
+
+## Variables
+
+_Note: When providing `_ref` values, please ensure that these are prefixed with the correct location details depending if the connector is at the Organization (org.) or Account (account.) levels.  For Project Connectors, nothing else is required excluding the reference ID for the connector._
+
+| Name | Description | Type | Default Value | Mandatory |
+| --- | --- | --- | --- | --- |
+| harness_platform_url | Enter the Harness Platform URL.  Defaults to Harness SaaS URL | string | https://app.harness.io/gateway | X |
+| harness_platform_account | Enter the Harness Platform Account Number | string | null | X |
+| harness_platform_key | Enter the Harness Platform API Key for your account | string | null | X |
+| organization_name | Provide an organization name.  Must be two or more characters | string | | X |
+| create_organization | Should this execution create a new Organization | bool | false | X |
+| project_name | Provide an project name.  Must be two or more characters | string | | X |
+| create_project | Should this execution create a new Project | bool | false | X |
+| container_registry | Registry to which the image will be saved and stored | string | | X |
+| container_registry_type | Registry Type to which images will be pushed. Supported Values - azure or docker | string | | X |
+| container_registry_connector_ref | Container Registry Connector Reference (see above _note:_)| string | | X |
+| kubernetes_connector_ref | Kubernetes Connector Reference (see above _note:_) | string | | X |
+| kubernetes_namespace |  Namespace within Cluster in which the CI process will build | string | | X |
+| max_build_concurrency |  number of simultaneous builds to perform | string | 5 | X |
+| enable_schedule | Should we enable the execution of this pipeline to run on a schedule? | bool | true | |
+| schedule | Cron Format schedule for when and how frequently to schedule this pipeline | string | "0 2 * * *" | |
+
+
+
+## Terraform TFVARS
+Included in this repository is a `terraform.tfvars.example` file with a sample file that can be used to construct your own `terraform.tfvars` file.
+
+- Save a copy of the file as `terraform.tfvars`
+- Update the variable values listed in the new TFVAR file
+
+## Outputs
+| Name | Description | Value |
+| --- | --- | --- |
+| pipeline | Details for the created Harness pipeline | Map containing details of created pipeline |
+
+## Contributing
+A complete [Contributors Guide](../CONTRIBUTING.md) can be found in this repository
+
+## Authors
+Module is maintained by Harness, Inc
+
+## License
+
+MIT License. See [LICENSE](../LICENSE) for full details.

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -1,8 +1,27 @@
 # Harness CI Image Factory
 A collection of Terraform resources centered around the implementation of the Harness CI Factory Pipeline to support managing Harness CI Container Images
 
-## Goal
-TODO
+## TLDR
+
+```terraform
+module "harness-ci-factory" {
+  source = "git@github.com:harness-community/solutions-architecture.git//harness-ci-factory?ref=main"
+
+  harness_api_key_secret           = "account.harness_api_token"
+  organization_name                = "harness-ci-factory"
+  create_organization              = true
+  project_name                     = "harness-ci-factory"
+  create_project                   = true
+  container_registry               = "registry.example.com"
+  container_registry_type          = "docker"
+  container_registry_connector_ref = "account.registry_example_com"
+  kubernetes_connector_ref         = "account.example_cluster"
+  kubernetes_namespace             = "harnesscifactory"
+  max_build_concurrency            = 5
+  enable_schedule                  = false
+  schedule                         = "0 2 * * *"
+}
+```
 
 ## Summary
 As the Harness Solutions Architecture team, we have developed a pipeline to manage the injestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -4,6 +4,8 @@ A collection of Terraform resources centered around the implementation of the Ha
 
 ## TLDR
 
+_Note: The use of this module requires that the calling template also includes a Harness Terraform Provider configuration.  Learn [How to setup the Harness Terraform Provider](#providers)_
+
 ```terraform
 module "harness-ci-factory" {
   source = "git@github.com:harness-community/solutions-architecture.git//harness-ci-factory?ref=main"

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -24,7 +24,7 @@ module "harness-ci-factory" {
 ```
 
 ## Summary
-As the Harness Solutions Architecture team, we have developed a pipeline to manage the injestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
+As the Harness Solutions Architecture team, we have developed a pipeline to manage the ingestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
 
 - An optional new Harness Organization
 - An optional new Harness Project in the chosen Organization

--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -90,6 +90,7 @@ _Note: When providing `_ref` values, please ensure that these are prefixed with 
 | harness_platform_url | Enter the Harness Platform URL.  Defaults to Harness SaaS URL | string | https://app.harness.io/gateway | X |
 | harness_platform_account | Enter the Harness Platform Account Number | string | null | X |
 | harness_platform_key | Enter the Harness Platform API Key for your account | string | null | X |
+| harness_api_key_secret | Enter the Harness secret that holds an API key for your account | string | | X |
 | organization_name | Provide an organization name.  Must be two or more characters | string | | X |
 | create_organization | Should this execution create a new Organization | bool | false | X |
 | project_name | Provide an project name.  Must be two or more characters | string | | X |

--- a/harness-ci-factory/locals.tf
+++ b/harness-ci-factory/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  build_push_target = {
+    azure  = "harness-ci-build-images-azure.yaml"
+    docker = "harness-ci-build-images-docker.yaml"
+  }
+}

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -1,6 +1,6 @@
 module "organization" {
   source  = "harness-community/structure/harness//modules/organizations"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name     = var.organization_name
   existing = var.create_organization ? false : true
@@ -8,7 +8,7 @@ module "organization" {
 
 module "project" {
   source  = "harness-community/structure/harness//modules/projects"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name            = var.project_name
   organization_id = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -1,6 +1,6 @@
 module "organization" {
   source  = "harness-community/structure/harness//modules/organizations"
-  version = "0.1.1"
+  version = "0.1.2"
 
   name     = var.organization_name
   existing = var.create_organization ? false : true
@@ -8,10 +8,10 @@ module "organization" {
 
 module "project" {
   source  = "harness-community/structure/harness//modules/projects"
-  version = "0.1.1"
+  version = "0.1.2"
 
   name            = var.project_name
-  organization_id = module.organization.organization_details.id
+  organization_id = module.organization.details.id
   existing        = var.create_project ? false : true
 }
 
@@ -20,8 +20,8 @@ module "gather-harness-ci-images-template" {
   version = "0.1.1"
 
   name             = "Gather Harness CI Images"
-  organization_id  = module.organization.organization_details.id
-  project_id       = module.project.project_details.id
+  organization_id  = module.organization.details.id
+  project_id       = module.project.details.id
   template_version = "v1.0.0"
   type             = "Stage"
   yaml_data = templatefile(
@@ -42,8 +42,8 @@ module "build-push-template" {
   version = "0.1.1"
 
   name             = "Build and Push Harness CI Standard Images"
-  organization_id  = module.organization.organization_details.id
-  project_id       = module.project.project_details.id
+  organization_id  = module.organization.details.id
+  project_id       = module.project.details.id
   template_version = "v1.0.0"
   type             = "Stage"
   yaml_data = templatefile(
@@ -68,8 +68,8 @@ module "harness-ci-image-factory" {
 
   name            = "Harness CI Image Factory"
   description     = "This pipeline will find, build, push, and configure Harness Platform to retrieve CI build images from a custom registry"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   yaml_data = templatefile(
     "${path.module}/templates/pipelines/harness-ci-image-factory.yaml",
     {
@@ -96,8 +96,8 @@ module "harness-ci-image-factory-cleanup" {
 
   name            = "Harness CI Image Factory - Reset Images to Harness"
   description     = "This pipeline will reset the custom images back to the default Harness Platform values"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   yaml_data = templatefile(
     "${path.module}/templates/pipelines/harness-ci-image-reset.yaml",
     {
@@ -117,8 +117,8 @@ module "pipeline-execution-schedule" {
   version = "0.1.1"
 
   name            = "Retrieve and Build Images"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   pipeline_id     = module.harness-ci-image-factory.details.id
   trigger_enabled = var.enable_schedule
   yaml_data = templatefile(

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -115,7 +115,7 @@ module "pipeline-execution-schedule" {
   pipeline_id     = module.harness-ci-image-factory.details.id
   trigger_enabled = var.enable_schedule
   yaml_data = templatefile(
-    "templates/triggers/retrieve-and-build-images.yaml",
+    "${path.module}/templates/triggers/retrieve-and-build-images.yaml",
     {
       SCHEDULE : var.schedule
       REGISTRY_NAME : var.container_registry

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -1,0 +1,104 @@
+module "organization" {
+  source = "github.com/harness-community/terraform-harness-structure//modules/organizations"
+
+  name     = var.organization_name
+  existing = var.create_organization ? false : true
+}
+
+module "project" {
+  source = "github.com/harness-community/terraform-harness-structure//modules/projects"
+
+  name            = var.project_name
+  organization_id = module.organization.organization_details.id
+  existing        = var.create_project ? false : true
+}
+
+module "gather-harness-ci-images-template" {
+  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+
+  name             = "Gather Harness CI Images"
+  organization_id  = module.organization.organization_details.id
+  project_id       = module.project.project_details.id
+  template_version = "v1.0.0"
+  type             = "Stage"
+  yaml_data = templatefile(
+    "templates/templates/gather-harness-ci-image-list.yaml",
+    {
+      HARNESS_URL : var.harness_platform_url
+    }
+  )
+  tags = {
+    role = "harness-ci-image-factory"
+  }
+
+}
+
+module "build-push-template" {
+  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+
+  name             = "Build and Push Harness CI Standard Images"
+  organization_id  = module.organization.organization_details.id
+  project_id       = module.project.project_details.id
+  template_version = "v1.0.0"
+  type             = "Stage"
+  yaml_data = templatefile(
+    "templates/templates/${lookup(local.build_push_target, var.container_registry_type, "MISSING-REGISTRY-TEMPLATE")}",
+    {
+      REGISTRY_NAME : var.container_registry
+      MAX_CONCURRENCY : var.max_build_concurrency
+      CONTAINER_REGISTRY_CONNECTOR : var.container_registry_connector_ref
+      KUBERNETES_CONNECTOR_REF : var.kubernetes_connector_ref
+      KUBERNETES_NAMESPACE : var.kubernetes_namespace
+    }
+  )
+  tags = {
+    role = "harness-ci-image-factory"
+  }
+
+}
+
+module "harness-ci-image-factory" {
+  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+
+  name            = "Harness CI Image Factory"
+  organization_id = module.organization.organization_details.id
+  project_id      = module.project.project_details.id
+  yaml_data = templatefile(
+    "templates/pipelines/harness-ci-image-factory.yaml",
+    {
+      HARNESS_URL : var.harness_platform_url
+      GATHER_SCAN_TEMPLATE : module.gather-harness-ci-images-template.details.id
+      BUILD_PUSH_TEMPLATE : module.build-push-template.details.id
+      REGISTRY_NAME : var.container_registry
+      MAX_CONCURRENCY : var.max_build_concurrency
+      CONTAINER_REGISTRY_CONNECTOR : var.container_registry_connector_ref
+      KUBERNETES_CONNECTOR_REF : var.kubernetes_connector_ref
+      KUBERNETES_NAMESPACE : var.kubernetes_namespace
+    }
+  )
+  tags = {
+    role = "harness-ci-image-factory"
+  }
+
+}
+
+module "pipeline-execution-schedule" {
+  source = "git@github.com:harness-community/terraform-harness-content.git//modules/triggers"
+
+  name            = "Retrieve and Build Images"
+  organization_id = module.organization.organization_details.id
+  project_id      = module.project.project_details.id
+  pipeline_id     = module.harness-ci-image-factory.details.id
+  trigger_enabled = var.enable_schedule
+  yaml_data = templatefile(
+    "templates/triggers/retrieve-and-build-images.yaml",
+    {
+      SCHEDULE : var.schedule
+      REGISTRY_NAME : var.container_registry
+    }
+  )
+  tags = {
+    role = "harness-ci-image-factory"
+  }
+
+}

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -7,7 +7,8 @@ module "organization" {
 }
 
 module "project" {
-  source = "github.com/harness-community/terraform-harness-structure//modules/projects"
+  source  = "harness-community/structure/harness//modules/projects"
+  version = "0.1.0"
 
   name            = var.project_name
   organization_id = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -63,7 +63,8 @@ module "build-push-template" {
 }
 
 module "harness-ci-image-factory" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+  source  = "harness-community/content/harness//modules/pipelines"
+  version = "0.1.0"
 
   name            = "Harness CI Image Factory"
   description     = "This pipeline will find, build, push, and configure Harness Platform to retrieve CI build images from a custom registry"

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -66,7 +66,7 @@ module "harness-ci-image-factory" {
   organization_id = module.organization.organization_details.id
   project_id      = module.project.project_details.id
   yaml_data = templatefile(
-    "templates/pipelines/harness-ci-image-factory.yaml",
+    "${path.module}/templates/pipelines/harness-ci-image-factory.yaml",
     {
       HARNESS_URL : var.harness_platform_url
       HARNESS_API_KEY_SECRET : var.harness_api_key_secret

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -114,7 +114,7 @@ module "harness-ci-image-factory-cleanup" {
 
 module "pipeline-execution-schedule" {
   source  = "harness-community/content/harness//modules/triggers"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name            = "Retrieve and Build Images"
   organization_id = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -1,5 +1,6 @@
 module "organization" {
-  source = "github.com/harness-community/terraform-harness-structure//modules/organizations"
+  source  = "harness-community/structure/harness//modules/organizations"
+  version = "0.1.0"
 
   name     = var.organization_name
   existing = var.create_organization ? false : true

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -90,7 +90,8 @@ module "harness-ci-image-factory" {
 }
 
 module "harness-ci-image-factory-cleanup" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+  source  = "harness-community/content/harness//modules/pipelines"
+  version = "0.1.0"
 
   name            = "Harness CI Image Factory - Reset Images to Harness"
   description     = "This pipeline will reset the custom images back to the default Harness Platform values"

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -25,6 +25,7 @@ module "gather-harness-ci-images-template" {
     "templates/templates/gather-harness-ci-image-list.yaml",
     {
       HARNESS_URL : var.harness_platform_url
+      HARNESS_API_KEY_SECRET : var.harness_api_key_secret
     }
   )
   tags = {
@@ -67,6 +68,7 @@ module "harness-ci-image-factory" {
     "templates/pipelines/harness-ci-image-factory.yaml",
     {
       HARNESS_URL : var.harness_platform_url
+      HARNESS_API_KEY_SECRET : var.harness_api_key_secret
       GATHER_SCAN_TEMPLATE : module.gather-harness-ci-images-template.details.id
       BUILD_PUSH_TEMPLATE : module.build-push-template.details.id
       REGISTRY_NAME : var.container_registry

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -17,7 +17,7 @@ module "project" {
 
 module "gather-harness-ci-images-template" {
   source  = "harness-community/content/harness//modules/templates"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name             = "Gather Harness CI Images"
   organization_id  = module.organization.organization_details.id
@@ -39,7 +39,7 @@ module "gather-harness-ci-images-template" {
 
 module "build-push-template" {
   source  = "harness-community/content/harness//modules/templates"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name             = "Build and Push Harness CI Standard Images"
   organization_id  = module.organization.organization_details.id
@@ -64,7 +64,7 @@ module "build-push-template" {
 
 module "harness-ci-image-factory" {
   source  = "harness-community/content/harness//modules/pipelines"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name            = "Harness CI Image Factory"
   description     = "This pipeline will find, build, push, and configure Harness Platform to retrieve CI build images from a custom registry"
@@ -92,7 +92,7 @@ module "harness-ci-image-factory" {
 
 module "harness-ci-image-factory-cleanup" {
   source  = "harness-community/content/harness//modules/pipelines"
-  version = "0.1.0"
+  version = "0.1.1"
 
   name            = "Harness CI Image Factory - Reset Images to Harness"
   description     = "This pipeline will reset the custom images back to the default Harness Platform values"

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -22,7 +22,7 @@ module "gather-harness-ci-images-template" {
   template_version = "v1.0.0"
   type             = "Stage"
   yaml_data = templatefile(
-    "templates/templates/gather-harness-ci-image-list.yaml",
+    "${path.module}/templates/templates/gather-harness-ci-image-list.yaml",
     {
       HARNESS_URL : var.harness_platform_url
       HARNESS_API_KEY_SECRET : var.harness_api_key_secret

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -112,7 +112,8 @@ module "harness-ci-image-factory-cleanup" {
 }
 
 module "pipeline-execution-schedule" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/triggers"
+  source  = "harness-community/content/harness//modules/triggers"
+  version = "0.1.0"
 
   name            = "Retrieve and Build Images"
   organization_id = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -38,7 +38,8 @@ module "gather-harness-ci-images-template" {
 }
 
 module "build-push-template" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+  source  = "harness-community/content/harness//modules/templates"
+  version = "0.1.0"
 
   name             = "Build and Push Harness CI Standard Images"
   organization_id  = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -93,7 +93,7 @@ module "harness-ci-image-factory-cleanup" {
   organization_id = module.organization.organization_details.id
   project_id      = module.project.project_details.id
   yaml_data = templatefile(
-    "templates/pipelines/harness-ci-image-reset.yaml",
+    "${path.module}/templates/pipelines/harness-ci-image-reset.yaml",
     {
       HARNESS_URL : var.harness_platform_url
       HARNESS_API_KEY_SECRET : var.harness_api_key_secret

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -16,7 +16,8 @@ module "project" {
 }
 
 module "gather-harness-ci-images-template" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+  source  = "harness-community/content/harness//modules/templates"
+  version = "0.1.0"
 
   name             = "Gather Harness CI Images"
   organization_id  = module.organization.organization_details.id

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -62,6 +62,7 @@ module "harness-ci-image-factory" {
   source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
 
   name            = "Harness CI Image Factory"
+  description     = "This pipeline will find, build, push, and configure Harness Platform to retrieve CI build images from a custom registry"
   organization_id = module.organization.organization_details.id
   project_id      = module.project.project_details.id
   yaml_data = templatefile(
@@ -76,6 +77,27 @@ module "harness-ci-image-factory" {
       CONTAINER_REGISTRY_CONNECTOR : var.container_registry_connector_ref
       KUBERNETES_CONNECTOR_REF : var.kubernetes_connector_ref
       KUBERNETES_NAMESPACE : var.kubernetes_namespace
+    }
+  )
+  tags = {
+    role = "harness-ci-image-factory"
+  }
+
+}
+
+module "harness-ci-image-factory-cleanup" {
+  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+
+  name            = "Harness CI Image Factory - Reset Images to Harness"
+  description     = "This pipeline will reset the custom images back to the default Harness Platform values"
+  organization_id = module.organization.organization_details.id
+  project_id      = module.project.project_details.id
+  yaml_data = templatefile(
+    "templates/pipelines/harness-ci-image-reset.yaml",
+    {
+      HARNESS_URL : var.harness_platform_url
+      HARNESS_API_KEY_SECRET : var.harness_api_key_secret
+      GATHER_SCAN_TEMPLATE : module.gather-harness-ci-images-template.details.id
     }
   )
   tags = {

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -43,7 +43,7 @@ module "build-push-template" {
   template_version = "v1.0.0"
   type             = "Stage"
   yaml_data = templatefile(
-    "templates/templates/${lookup(local.build_push_target, var.container_registry_type, "MISSING-REGISTRY-TEMPLATE")}",
+    "${path.module}/templates/templates/${lookup(local.build_push_target, var.container_registry_type, "MISSING-REGISTRY-TEMPLATE")}",
     {
       REGISTRY_NAME : var.container_registry
       MAX_CONCURRENCY : var.max_build_concurrency

--- a/harness-ci-factory/outputs.tf
+++ b/harness-ci-factory/outputs.tf
@@ -1,0 +1,3 @@
+output "pipeline" {
+  value = module.harness-ci-image-factory.details
+}

--- a/harness-ci-factory/providers.tf
+++ b/harness-ci-factory/providers.tf
@@ -1,0 +1,5 @@
+provider "harness" {
+  endpoint         = var.harness_platform_url
+  account_id       = var.harness_platform_account
+  platform_api_key = var.harness_platform_key
+}

--- a/harness-ci-factory/providers.tf
+++ b/harness-ci-factory/providers.tf
@@ -1,5 +1,0 @@
-provider "harness" {
-  endpoint         = var.harness_platform_url
-  account_id       = var.harness_platform_account
-  platform_api_key = var.harness_platform_key
-}

--- a/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
+++ b/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
@@ -1,0 +1,139 @@
+stages:
+  - stage:
+      name: Gather Harness Images
+      identifier: gather_harness_images
+      description: Reads official Harness API to gather a list of the Harness Images used for pipeline execution
+      template:
+        templateRef: ${GATHER_SCAN_TEMPLATE}
+  - stage:
+      name: Build and Push Images
+      identifier: build_and_push_images
+      description: ""
+      template:
+        templateRef: ${BUILD_PUSH_TEMPLATE}
+      strategy:
+        repeat:
+          items: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images.split(",")>
+          maxConcurrency: ${MAX_CONCURRENCY}
+      variables:
+        - name: IMAGE_NAME
+          type: String
+          value: <+repeat.item.split("=")[1].split(":")[0]>
+        - name: IMAGE_VERSION
+          type: String
+          value: <+repeat.item.split("=")[1].split(":")[1]>
+        - name: IMAGE
+          type: String
+          value: <+repeat.item.split("=")[1]>
+      when:
+        pipelineStatus: Success
+        condition: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images> != ""
+  - stage:
+      name: Update Harness CI Image Configuration
+      identifier: update_harness_ci_image_configuration
+      description: "This stage will update the Harness Platform to use the newly pushed images as the default versions when running CI pipelines"
+      type: Custom
+      spec:
+        execution:
+          steps:
+            - step:
+                type: Http
+                name: Update Custom Configuration of Images
+                identifier: Update_Custom_Configuration_of_Images
+                spec:
+                  url: ${HARNESS_URL}/ci/execution-config/update-config?accountIdentifier=<+account.identifier>&infra=k8
+                  method: POST
+                  assertion: <+httpResponseCode> == 200
+                  headers:
+                    - key: X-API-KEY
+                      value: <+secrets.getValue("account.harness_platform_key")>
+                    - key: Content-Type
+                      value: application/json
+                  outputVariables: []
+                  requestBody: |
+                    [
+                        {
+                            "field": "<+repeat.item.split("=")[0]>",
+                            "value": "<+pipeline.variables.registry>/<+repeat.item.split("=")[1]>"
+                        }
+                    ]
+                timeout: 30s
+      tags: {}
+      strategy:
+        repeat:
+          items: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images.split(",")>
+          maxConcurrency: ${MAX_CONCURRENCY}
+      when:
+        pipelineStatus: Success
+        condition: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images> != ""
+  - stage:
+      name: Pause to recheck status
+      identifier: pause_to_recheck_status
+      description: ""
+      type: Custom
+      spec:
+        execution:
+          steps:
+            - step:
+                type: Wait
+                name: Wait for 30 seconds
+                identifier: Wait_for_30_seconds
+                spec:
+                  duration: 30s
+      tags: {}
+  - stage:
+      name: Verify Harness Images
+      identifier: verify_harness_images
+      description: Reads official Harness API to gather a list of the Harness Images used for pipeline execution
+      template:
+        templateRef: ${GATHER_SCAN_TEMPLATE}
+  - stage:
+      name: Build Missing Images
+      identifier: build_missing_images
+      description: "If additional images have been found, we will retrigger this pipeline to resolve the missing images"
+      type: Custom
+      spec:
+        execution:
+          steps:
+            - step:
+                type: Http
+                name: Missing Images Require Execution
+                identifier: Missing_Images_Require_Execution
+                spec:
+                  url: ${HARNESS_URL}/pipeline/api/pipeline/execute/<+pipeline.identifier>?accountIdentifier=<+account.identifier>&orgIdentifier=<+org.identifier>&projectIdentifier=<+project.identifier>
+                  method: POST
+                  assertion: <+httpResponseCode> == 200
+                  headers:
+                    - key: X-API-KEY
+                      value: <+secrets.getValue("account.harness_platform_key")>
+                    - key: Content-Type
+                      value: application/yaml
+                  requestBody: |
+                    pipeline:
+                      identifier: <+pipeline.identifier>
+                      variables:
+                        - name: registry
+                          value: <+pipeline.variables.registry>
+                        - name: is_retry
+                          value: "true"
+                  outputVariables: []
+                timeout: 30s
+                when:
+                  stageStatus: Success
+                  condition: "!<+pipeline.variables.is_retry>"
+      tags: {}
+      when:
+        condition: <+pipeline.stages.verify_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images> != ""
+        pipelineStatus: Success
+variables:
+  - name: registry
+    description: Container Registry to which the image will be saved and stored.
+    type: String
+    value: <+input>
+    default: ${REGISTRY_NAME}
+  - name: is_retry
+    description: Container Registry to which the image will be saved and stored.
+    type: String
+    value: <+input>.allowedValues(true,false)
+    default: "false"
+

--- a/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
+++ b/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
@@ -46,7 +46,7 @@ stages:
                   assertion: <+httpResponseCode> == 200
                   headers:
                     - key: X-API-KEY
-                      value: <+secrets.getValue("account.harness_platform_key")>
+                      value: <+secrets.getValue("${HARNESS_API_KEY_SECRET}")>
                     - key: Content-Type
                       value: application/json
                   outputVariables: []
@@ -105,7 +105,7 @@ stages:
                   assertion: <+httpResponseCode> == 200
                   headers:
                     - key: X-API-KEY
-                      value: <+secrets.getValue("account.harness_platform_key")>
+                      value: <+secrets.getValue("${HARNESS_API_KEY_SECRET}")>
                     - key: Content-Type
                       value: application/yaml
                   requestBody: |

--- a/harness-ci-factory/templates/pipelines/harness-ci-image-reset.yaml
+++ b/harness-ci-factory/templates/pipelines/harness-ci-image-reset.yaml
@@ -1,0 +1,46 @@
+
+stages:
+  - stage:
+      name: Gather Harness Images
+      identifier: gather_harness_images
+      description: Reads official Harness API to gather a list of the Harness Images used for pipeline execution
+      template:
+        templateRef: ${GATHER_SCAN_TEMPLATE}
+  - stage:
+      name: CLEANUP
+      identifier: CLEANUP
+      description: ""
+      type: Custom
+      spec:
+        execution:
+          steps:
+            - step:
+                type: Http
+                name: Reset Custom Configuration of Images
+                identifier: Reset_Custom_Configuration_of_Images
+                spec:
+                  url: ${HARNESS_URL}/ci/execution-config/reset-config?accountIdentifier=<+account.identifier>&infra=k8
+                  method: POST
+                  assertion: <+httpResponseCode> == 200
+                  headers:
+                    - key: X-API-KEY
+                      value: <+secrets.getValue("${HARNESS_API_KEY_SECRET}")>
+                    - key: Content-Type
+                      value: application/json
+                  outputVariables: []
+                  requestBody: "[    {        \"field\": \"<+stage.variables.field_name>\"    }]"
+                timeout: 30s
+      tags: {}
+      when:
+        pipelineStatus: Success
+      strategy:
+        repeat:
+          items: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images.split(",")>
+          maxConcurrency: 5
+      variables:
+        - name: field_name
+          type: String
+          description: ""
+          value: <+repeat.item.split("=")[0]>
+timeout: 10m
+variables: []

--- a/harness-ci-factory/templates/templates/gather-harness-ci-image-list.yaml
+++ b/harness-ci-factory/templates/templates/gather-harness-ci-image-list.yaml
@@ -1,0 +1,103 @@
+# Gather and Collate available and in-use Harness CI Image details
+spec:
+  type: Custom
+  tags: {}
+  spec:
+    execution:
+      steps:
+        - step:
+            name: Gather Current Custom Images
+            identifier: gather_current_custom_images
+            type: Http
+            spec:
+              url: ${HARNESS_URL}/ci/execution-config/get-customer-config?accountIdentifier=<+account.identifier>&infra=k8&overridesOnly=true
+              method: GET
+              assertion: <+httpResponseCode> == 200
+              headers:
+                - key: X-API-KEY
+                  value: <+secrets.getValue("account.harness_platform_key")>
+              outputVariables:
+                - name: agents
+                  type: String
+                  value: <+json.list("data", json.format(json.object(httpResponseBody)))>
+            timeout: 10s
+        - step:
+            name: Download Harness Image List
+            identifier: download_harness_image_list
+            type: Http
+            spec:
+              url: ${HARNESS_URL}/ci/execution-config/get-default-config?accountIdentifier=<+account.identifier>&infra=k8
+              method: GET
+              assertion: <+httpResponseCode> == 200
+              headers:
+                - key: X-API-KEY
+                  value: <+secrets.getValue("account.harness_platform_key")>
+              outputVariables:
+                - name: agents
+                  type: String
+                  value: <+json.list("data", json.format(json.object(httpResponseBody)))>
+            timeout: 10s
+        - step:
+            name: Get List of Images to Update
+            identifier: get_list_of_images_to_update
+            type: ShellScript
+            spec:
+              shell: Bash
+              onDelegate: true
+              source:
+                type: Inline
+                spec:
+                  script: |-
+                    set -eo pipefail
+                    echo "Begin Processing List of images"
+
+                    function parse_list () {
+                        local list=$1
+                        local new_list=($(echo $list | sed -r 's/[\{|\}]//g' | sed -r 's/ //g' | sed -r "s/$${REGISTRY}\///g" | tr "," "\n"))
+                        echo "$${new_list[@]}"
+                    }
+
+                    DEFAULT_IMAGES=$(parse_list "$DEFAULT_IMAGES")
+                    CUSTOMER_IMAGES=$(parse_list "$CUSTOMER_IMAGES")
+                    new_image_list=()
+
+                    echo "Determine changed images"
+                    for image in $DEFAULT_IMAGES
+                    do
+                        image=$(echo $image | sed -r "s/$${REGISTRY}\///")
+                        # We want a valid image for some run step work and the best choice will be
+                        # the current CI addonTag image as it will always be pulled and should be current.
+                        if [[ -n `echo "$${image}" | grep addonTag` ]]; then
+                          RUNNER_IMAGE="`echo $${image} | cut -d"=" -f2`"
+                        fi
+
+                        # Check the image against the current customer image list to verify if the
+                        # image should be built
+                        if [[ ! "$${CUSTOMER_IMAGES[*]}" =~ "$${image}" ]]; then
+                            echo "- $${image} is different"
+                            new_image_list+=($image)
+                        fi
+                    done
+
+                    echo "Generate Output"
+                    new_image_list="$${new_image_list[*]}"
+                    FINAL_IMAGE_LIST=$${new_image_list// /,}
+
+              environmentVariables:
+                - name: CUSTOMER_IMAGES
+                  type: String
+                  value: <+stage.spec.execution.steps.gather_current_custom_images.output.outputVariables.agents>
+                - name: DEFAULT_IMAGES
+                  type: String
+                  value: <+stage.spec.execution.steps.download_harness_image_list.output.outputVariables.agents>
+                - name: REGISTRY
+                  type: String
+                  value: <+pipeline.variables.registry>
+              outputVariables:
+                - name: images
+                  type: String
+                  value: FINAL_IMAGE_LIST
+                - name: runner
+                  type: String
+                  value: RUNNER_IMAGE
+            timeout: 5m

--- a/harness-ci-factory/templates/templates/gather-harness-ci-image-list.yaml
+++ b/harness-ci-factory/templates/templates/gather-harness-ci-image-list.yaml
@@ -15,7 +15,7 @@ spec:
               assertion: <+httpResponseCode> == 200
               headers:
                 - key: X-API-KEY
-                  value: <+secrets.getValue("account.harness_platform_key")>
+                  value: <+secrets.getValue("${HARNESS_API_KEY_SECRET}")>
               outputVariables:
                 - name: agents
                   type: String
@@ -31,7 +31,7 @@ spec:
               assertion: <+httpResponseCode> == 200
               headers:
                 - key: X-API-KEY
-                  value: <+secrets.getValue("account.harness_platform_key")>
+                  value: <+secrets.getValue("${HARNESS_API_KEY_SECRET}")>
               outputVariables:
                 - name: agents
                   type: String

--- a/harness-ci-factory/templates/templates/harness-ci-build-images-azure.yaml
+++ b/harness-ci-factory/templates/templates/harness-ci-build-images-azure.yaml
@@ -1,0 +1,59 @@
+# Gather and Collate available and in-use Harness CI Image details
+spec:
+  type: CI
+  spec:
+    cloneCodebase: false
+    infrastructure:
+      type: KubernetesDirect
+      spec:
+        connectorRef: ${KUBERNETES_CONNECTOR_REF}
+        namespace: ${KUBERNETES_NAMESPACE}
+        automountServiceAccountToken: true
+        nodeSelector: {}
+        os: Linux
+    execution:
+      steps:
+        - step:
+            identifier: Generate_Dockerfile
+            name: Generate Dockerfile
+            description: This step will create a new Dockerfile to be leveraged in the upcoming Build and Push step.  In addition this step leverages the RUNNER_IMAGE retrieved from the 'Gather Harness Images' stage.
+            type: Run
+            spec:
+              connectorRef: account.harnessImage
+              image: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.runner>
+              shell: Sh
+              command: |
+                set -eo pipefail
+                set +x
+                echo "Generating Dockerfile for $IMAGE"
+                echo "--------------"
+                mkdir -p $IMAGE_NAME
+                cat <<EOF >$IMAGE_NAME/Dockerfile
+                FROM $IMAGE
+                EOF
+                echo
+                echo "Display Generated Dockerfile"
+                echo "--------------"
+                cat $IMAGE_NAME/Dockerfile
+              envVariables:
+                IMAGE: <+stage.variables.IMAGE>
+                IMAGE_NAME: <+stage.variables.IMAGE_NAME>
+        - step:
+            type: BuildAndPushACR
+            identifier: BuildandPushtoACR
+            name: Build and Push to ACR
+            spec:
+              connectorRef: ${CONTAINER_REGISTRY_CONNECTOR}
+              repository: <+pipeline.variables.registry>/<+stage.variables.IMAGE_NAME>
+              tags:
+                - <+stage.variables.IMAGE_VERSION>
+              dockerfile: <+stage.variables.IMAGE_NAME>/Dockerfile
+            failureStrategies: []
+            when:
+              stageStatus: Success
+  tags: {}
+  variables:
+    - name: images
+      description: ""
+      type: String
+      value: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images>

--- a/harness-ci-factory/templates/templates/harness-ci-build-images-docker.yaml
+++ b/harness-ci-factory/templates/templates/harness-ci-build-images-docker.yaml
@@ -1,0 +1,59 @@
+# Gather and Collate available and in-use Harness CI Image details
+spec:
+  type: CI
+  spec:
+    cloneCodebase: false
+    infrastructure:
+      type: KubernetesDirect
+      spec:
+        connectorRef: ${KUBERNETES_CONNECTOR_REF}
+        namespace: ${KUBERNETES_NAMESPACE}
+        automountServiceAccountToken: true
+        nodeSelector: {}
+        os: Linux
+    execution:
+      steps:
+        - step:
+            identifier: Generate_Dockerfile
+            name: Generate Dockerfile
+            description: This step will create a new Dockerfile to be leveraged in the upcoming Build and Push step.  In addition this step leverages the RUNNER_IMAGE retrieved from the 'Gather Harness Images' stage.
+            type: Run
+            spec:
+              connectorRef: account.harnessImage
+              image: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.runner>
+              shell: Sh
+              command: |
+                set -eo pipefail
+                set +x
+                echo "Generating Dockerfile for $IMAGE"
+                echo "--------------"
+                mkdir -p $IMAGE_NAME
+                cat <<EOF >$IMAGE_NAME/Dockerfile
+                FROM $IMAGE
+                EOF
+                echo
+                echo "Display Generated Dockerfile"
+                echo "--------------"
+                cat $IMAGE_NAME/Dockerfile
+              envVariables:
+                IMAGE: <+stage.variables.IMAGE>
+                IMAGE_NAME: <+stage.variables.IMAGE_NAME>
+        - step:
+            type: BuildAndPushDockerRegistry
+            identifier: BuildandPushtoDocker
+            name: Build and Push to Docker
+            spec:
+              connectorRef: ${CONTAINER_REGISTRY_CONNECTOR}
+              repo: <+pipeline.variables.registry>/<+stage.variables.IMAGE_NAME>
+              tags:
+                - <+stage.variables.IMAGE_VERSION>
+              dockerfile: <+stage.variables.IMAGE_NAME>/Dockerfile
+            failureStrategies: []
+            when:
+              stageStatus: Success
+  tags: {}
+  variables:
+    - description: ""
+      name: images
+      type: String
+      value: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images>

--- a/harness-ci-factory/templates/triggers/retrieve-and-build-images.yaml
+++ b/harness-ci-factory/templates/triggers/retrieve-and-build-images.yaml
@@ -1,0 +1,16 @@
+source:
+  type: Scheduled
+  spec:
+    type: Cron
+    spec:
+      expression: ${SCHEDULE}
+inputYaml: |
+  pipeline:
+    identifier: harness_ci_image_factory
+    variables:
+      - name: registry
+        type: String
+        value: ${REGISTRY_NAME}
+      - name: is_retry
+        type: String
+        value: "false"

--- a/harness-ci-factory/terraform.tf
+++ b/harness-ci-factory/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    harness = {
+      source  = "harness/harness"
+      version = ">= 0.14"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.9.1"
+    }
+  }
+}

--- a/harness-ci-factory/terraform.tfvars.example
+++ b/harness-ci-factory/terraform.tfvars.example
@@ -1,0 +1,44 @@
+# [Optional] Enter the Harness Platform URL.  Defaults to Harness SaaS URL
+harness_platform_url = "https://app.harness.io/gateway"
+
+# [Required] Enter the Harness Platform Account Number
+harness_platform_account = # Required
+
+# [Required] Enter the Harness Platform API Key for your account
+harness_platform_key = # Required
+
+# [Required] Provide an organization name.  Must be two or more characters
+organization_name = # Required
+
+# [Optional] Should this execution create a new Organization
+create_organization = false
+
+# [Required] Provide an project name.  Must be two or more characters
+project_name = # Required
+
+# [Optional] Should this execution create a new Project
+create_project = false
+
+# [Required] Container Registry to which the image will be saved and stored
+container_registry = # Required
+
+# [Required] Type of Container Registry to which images will be pushed. Supported Values - azure or docker
+container_registry_type = # Required
+
+# [Required] Container Registry Connector Reference
+container_registry_connector_ref = # Required
+
+# [Required] Kubernetes Connector Reference
+kubernetes_connector_ref = # Required
+
+# [Required] Kubernetes Namespace within Cluster in which the CI process will build
+kubernetes_namespace = # Required
+
+# [Optional] Maximum number of simultaneous builds to perform
+max_build_concurrency = 5
+
+# [Optional] Should we enable the execution of this pipeline to run on a schedule?
+enable_schedule = false
+
+# [Optional] Cron Format schedule for when and how frequently to schedule this pipeline
+schedule = "0 2 * * *"

--- a/harness-ci-factory/terraform.tfvars.example
+++ b/harness-ci-factory/terraform.tfvars.example
@@ -1,12 +1,6 @@
 # [Optional] Enter the Harness Platform URL.  Defaults to Harness SaaS URL
 harness_platform_url = "https://app.harness.io/gateway"
 
-# [Required] Enter the Harness Platform Account Number
-harness_platform_account = # Required
-
-# [Required] Enter the Harness Platform API Key for your account
-harness_platform_key = # Required
-
 # [Required] Enter the Harness secret that holds an API key for your account
 harness_api_key_secret = # Required
 

--- a/harness-ci-factory/terraform.tfvars.example
+++ b/harness-ci-factory/terraform.tfvars.example
@@ -7,6 +7,9 @@ harness_platform_account = # Required
 # [Required] Enter the Harness Platform API Key for your account
 harness_platform_key = # Required
 
+# [Required] Enter the Harness secret that holds an API key for your account
+harness_api_key_secret = # Required
+
 # [Required] Provide an organization name.  Must be two or more characters
 organization_name = # Required
 

--- a/harness-ci-factory/variables.tf
+++ b/harness-ci-factory/variables.tf
@@ -5,20 +5,6 @@ variable "harness_platform_url" {
   default     = "https://app.harness.io/gateway"
 }
 
-variable "harness_platform_account" {
-  type        = string
-  description = "[Required] Enter the Harness Platform Account Number"
-  default     = null
-  sensitive   = true
-}
-
-variable "harness_platform_key" {
-  type        = string
-  description = "[Required] Enter the Harness Platform API Key for your account"
-  default     = null
-  sensitive   = true
-}
-
 variable "harness_api_key_secret" {
   type        = string
   description = "[Required] Enter the Harness secret that holds an API key for your account"

--- a/harness-ci-factory/variables.tf
+++ b/harness-ci-factory/variables.tf
@@ -1,0 +1,97 @@
+# Provider Setup Details
+variable "harness_platform_url" {
+  type        = string
+  description = "[Optional] Enter the Harness Platform URL.  Defaults to Harness SaaS URL"
+  default     = "https://app.harness.io/gateway"
+}
+
+variable "harness_platform_account" {
+  type        = string
+  description = "[Required] Enter the Harness Platform Account Number"
+  default     = null
+  sensitive   = true
+}
+
+variable "harness_platform_key" {
+  type        = string
+  description = "[Required] Enter the Harness Platform API Key for your account"
+  default     = null
+  sensitive   = true
+}
+
+variable "organization_name" {
+  type        = string
+  description = "[Required] Provide an organization name.  Must be two or more characters"
+}
+
+variable "create_organization" {
+  type        = bool
+  description = "[Optional] Should this execution create a new Organization"
+  default     = false
+}
+
+variable "project_name" {
+  type        = string
+  description = "[Required] Provide an project name.  Must be two or more characters"
+}
+
+variable "create_project" {
+  type        = bool
+  description = "[Optional] Should this execution create a new Project"
+  default     = false
+}
+
+variable "container_registry" {
+  type        = string
+  description = "Container Registry to which the image will be saved and stored"
+}
+
+variable "container_registry_type" {
+  type        = string
+  description = "Type of Container Registry to which images will be pushed. Supported Values - azure or docker"
+
+  validation {
+    condition = (
+      contains(["azure", "docker"], lower(var.container_registry_type))
+    )
+    error_message = <<EOF
+        Validation of an object failed.
+            * [Required] Container Registry Type must be one of following:
+              - azure
+              - docker
+        EOF
+  }
+}
+
+variable "container_registry_connector_ref" {
+  type        = string
+  description = "Container Registry Connector Reference"
+}
+
+variable "kubernetes_connector_ref" {
+  type        = string
+  description = "Kubernetes Connector Reference"
+}
+
+variable "kubernetes_namespace" {
+  type        = string
+  description = "Kubernetes Namespace within Cluster in which the CI process will build"
+}
+
+variable "max_build_concurrency" {
+  type        = string
+  description = "Maximum number of simultaneous builds to perform"
+  default     = 5
+}
+
+variable "enable_schedule" {
+  type        = bool
+  description = "[Optional] Should we enable the execution of this pipeline to run on a schedule?"
+  default     = true
+}
+
+variable "schedule" {
+  type        = string
+  description = "[Optional] Cron Format schedule for when and how frequently to schedule this pipeline"
+  default     = "0 2 * * *"
+}

--- a/harness-ci-factory/variables.tf
+++ b/harness-ci-factory/variables.tf
@@ -19,6 +19,11 @@ variable "harness_platform_key" {
   sensitive   = true
 }
 
+variable "harness_api_key_secret" {
+  type        = string
+  description = "[Required] Enter the Harness secret that holds an API key for your account"
+}
+
 variable "organization_name" {
   type        = string
   description = "[Required] Provide an organization name.  Must be two or more characters"


### PR DESCRIPTION
A Terraform template to build a custom Harness pipeline.  The pipeline will pull all listed Harness CI images into a list which is then used to build and push those images to the chosen container registry.