### PR TITLE
Reference modules via registry instead of git

### DIFF
--- a/terraform-development-factory/main.tf
+++ b/terraform-development-factory/main.tf
@@ -1,19 +1,22 @@
 module "organization" {
-  source = "github.com/harness-community/terraform-harness-structure//modules/organizations"
+  source  = "harness-community/structure/harness//modules/organizations"
+  version = "0.1.0"
 
   name     = var.organization_name
   existing = var.create_organization ? false : true
 }
 
 module "project" {
-  source = "github.com/harness-community/terraform-harness-structure//modules/projects"
+  source  = "harness-community/structure/harness//modules/projects"
+  version = "0.1.0"
 
   name            = var.project_name
   organization_id = module.organization.organization_details.id
 }
 
 module "templates" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+  source  = "harness-community/content/harness//modules/templates"
+  version = "0.1.1"
 
   name            = "Terraform Validation"
   organization_id = module.organization.organization_details.id
@@ -34,7 +37,9 @@ module "templates" {
 }
 
 module "pipelines" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+  source  = "harness-community/content/harness//modules/pipelines"
+  version = "0.1.1"
+
   for_each = {
     for pipeline in var.repositories : (pipeline) => pipeline
   }
@@ -57,7 +62,9 @@ module "pipelines" {
 
 }
 module "push_triggers" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/triggers"
+  source  = "harness-community/content/harness//modules/triggers"
+  version = "0.1.1"
+
   for_each = {
     for pipeline in var.repositories : (pipeline) => pipeline
   }
@@ -103,7 +110,9 @@ module "push_triggers" {
 }
 
 module "pull_request_triggers" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/triggers"
+  source  = "harness-community/content/harness//modules/triggers"
+  version = "0.1.1"
+
   for_each = {
     for pipeline in var.repositories : (pipeline) => pipeline
   }

--- a/terraform-development-factory/main.tf
+++ b/terraform-development-factory/main.tf
@@ -1,6 +1,6 @@
 module "organization" {
   source  = "harness-community/structure/harness//modules/organizations"
-  version = "0.1.0"
+  version = "0.1.2"
 
   name     = var.organization_name
   existing = var.create_organization ? false : true
@@ -8,10 +8,10 @@ module "organization" {
 
 module "project" {
   source  = "harness-community/structure/harness//modules/projects"
-  version = "0.1.0"
+  version = "0.1.2"
 
   name            = var.project_name
-  organization_id = module.organization.organization_details.id
+  organization_id = module.organization.details.id
 }
 
 module "templates" {
@@ -19,10 +19,10 @@ module "templates" {
   version = "0.1.1"
 
   name            = "Terraform Validation"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   yaml_data = templatefile(
-    "templates/templates/terraform-deployment.yaml",
+    "${path.module}/templates/templates/terraform-deployment.yaml",
     {
       TERRAFORM_FILES_PATH : var.terraform_files
       MAX_CONCURRENCY : var.max_concurrency
@@ -45,10 +45,10 @@ module "pipelines" {
   }
 
   name            = element(split("/", each.value), length(split("/", each.value)) - 1)
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   yaml_data = templatefile(
-    "templates/pipelines/terraform-module-execution.yaml",
+    "${path.module}/templates/pipelines/terraform-module-execution.yaml",
     {
       REPOSITORY : each.value
       TEMPLATE_ID : module.templates.details.id
@@ -70,12 +70,12 @@ module "push_triggers" {
   }
 
   name            = "Feature Push"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   pipeline_id     = module.pipelines[each.value].details.id
   trigger_enabled = var.enable_triggers
   yaml_data = templatefile(
-    "templates/triggers/push-trigger.yaml",
+    "${path.module}/templates/triggers/push-trigger.yaml",
     {
       HARNESS_PLATFORM_KEY_SECRET = (
         var.harness_api_key_location != "project"
@@ -118,12 +118,12 @@ module "pull_request_triggers" {
   }
 
   name            = "Pull Request"
-  organization_id = module.organization.organization_details.id
-  project_id      = module.project.project_details.id
+  organization_id = module.organization.details.id
+  project_id      = module.project.details.id
   pipeline_id     = module.pipelines[each.value].details.id
   trigger_enabled = var.enable_triggers
   yaml_data = templatefile(
-    "templates/triggers/pull-request-trigger.yaml",
+    "${path.module}/templates/triggers/pull-request-trigger.yaml",
     {
       HARNESS_PLATFORM_KEY_SECRET = (
         var.harness_api_key_location != "project"

--- a/terraform-harness-modules/README.md
+++ b/terraform-harness-modules/README.md
@@ -216,7 +216,8 @@ To deploy into a k8s cluster we need a connector. Connectors can use one of many
 
 ```terraform
 module "dev_k8s_delegate" {
-  source = "git@github.com:harness-community/terraform-harness-connectors.git//modules/kubernetes/cluster"
+  source = "harness-community/connectors/harness//modules/kubernetes/cluster"
+  version = "0.1.1"
 
   organization_id    = module.org_foo.organization_details.id
   project_id         = module.project_appX.project_details.id
@@ -233,7 +234,8 @@ To grab manifests and values from GitHub, we can create a connector using PAT or
 
 ```terraform
 module "github" {
-  source = "git@github.com:harness-community/terraform-harness-connectors.git//modules/scms/github"
+  source = "harness-community/connectors/harness//modules/scms/github"
+  version = "0.1.1"
 
   organization_id = module.org_foo.organization_details.id
   project_id      = module.project_appX.project_details.id
@@ -382,7 +384,8 @@ Creating a pipeline using terraform is as easy as placing the yaml into the reso
 
 ```terraform
 module "pipelines" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+  source = "harness-community/content/harness//modules/pipelines"
+  version = "0.1.1"
 
   organization_id = module.org_foo.organization_details.id
   project_id      = module.project_appX.project_details.id
@@ -424,7 +427,8 @@ We can also create templates for any resource using terraform, again by just pas
 
 ```terraform
 module "template" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+  source = "harness-community/content/harness//modules/templates"
+  version = "0.1.1"
 
   name             = "sample-step-template"
   yaml_data        = <<EOT

--- a/terraform-harness-modules/connectors.tf
+++ b/terraform-harness-modules/connectors.tf
@@ -1,5 +1,6 @@
 module "dev_k8s_delegate" {
-  source = "git@github.com:harness-community/terraform-harness-connectors.git//modules/kubernetes/cluster"
+  source  = "harness-community/connectors/harness//modules/kubernetes/cluster"
+  version = "0.1.1"
 
   organization_id    = module.org_foo.organization_details.id
   project_id         = module.project_appX.project_details.id
@@ -8,7 +9,8 @@ module "dev_k8s_delegate" {
 }
 
 module "github" {
-  source = "git@github.com:harness-community/terraform-harness-connectors.git//modules/scms/github"
+  source  = "harness-community/connectors/harness//modules/scms/github"
+  version = "0.1.1"
 
   organization_id = module.org_foo.organization_details.id
   project_id      = module.project_appX.project_details.id

--- a/terraform-harness-modules/content.tf
+++ b/terraform-harness-modules/content.tf
@@ -1,5 +1,6 @@
 module "pipeline" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/pipelines"
+  source  = "harness-community/content/harness//modules/pipelines"
+  version = "0.1.1"
 
   organization_id = module.org_foo.organization_details.id
   project_id      = module.project_appX.project_details.id
@@ -35,7 +36,8 @@ module "pipeline" {
 }
 
 module "template" {
-  source = "git@github.com:harness-community/terraform-harness-content.git//modules/templates"
+  source  = "harness-community/content/harness//modules/templates"
+  version = "0.1.1"
 
   name             = "sample-step-template"
   yaml_data        = <<EOT


### PR DESCRIPTION
We should reference modules through the terraform registry rather than through git. We should also pin it to a specific version.