### PR TITLE
feat: modify_default_image_config

### DIFF
--- a/harness-ci-factory/README.md
+++ b/harness-ci-factory/README.md
@@ -30,6 +30,8 @@ After pulling, building, and pushing the images to your registry you will need t
 
 ![image](https://user-images.githubusercontent.com/7338312/228593992-c5ad744b-ee5d-4dd2-b68a-0fdf968c90d6.png)
 
+If you do not want to edit this default connector, you can optionally set `modify_default_image_config` to false. Then in your CI stage under `infrastructure`>`advanced`>`override image connector` you would select the image connector where you saved the Harness images (`container_registry_connector_ref`).
+
 ## Summary
 
 As the Harness Solutions Architecture team, we have developed a pipeline to manage the ingestion of Harness CI Build images into a customer maintained Container Registry.  This template will build and deliver the following:
@@ -133,6 +135,7 @@ _Note: When providing `_ref` values, please ensure that these are prefixed with 
 | max_build_concurrency |  number of simultaneous builds to perform | string | 5 | X |
 | enable_schedule | Should we enable the execution of this pipeline to run on a schedule? | bool | true | |
 | schedule | Cron Format schedule for when and how frequently to schedule this pipeline | string | "0 2 * * *" | |
+| modify_default_image_config | Update the Harness Platform to use the newly pushed images as the default versions when running CI pipelines. (requires modification of the harnessImages docker connector) | bool | true | |
 
 
 ## Terraform TFVARS

--- a/harness-ci-factory/main.tf
+++ b/harness-ci-factory/main.tf
@@ -82,6 +82,7 @@ module "harness-ci-image-factory" {
       CONTAINER_REGISTRY_CONNECTOR : var.container_registry_connector_ref
       KUBERNETES_CONNECTOR_REF : var.kubernetes_connector_ref
       KUBERNETES_NAMESPACE : var.kubernetes_namespace
+      MODIFY_DEFAULT : tostring(var.modify_default_image_config)
     }
   )
   tags = {

--- a/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
+++ b/harness-ci-factory/templates/pipelines/harness-ci-image-factory.yaml
@@ -65,7 +65,7 @@ stages:
           maxConcurrency: ${MAX_CONCURRENCY}
       when:
         pipelineStatus: Success
-        condition: <+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images> != ""
+        condition: (<+pipeline.stages.gather_harness_images.spec.execution.steps.get_list_of_images_to_update.output.outputVariables.images> != "") && <+pipeline.variables.modify_default>
   - stage:
       name: Pause to recheck status
       identifier: pause_to_recheck_status
@@ -136,4 +136,8 @@ variables:
     type: String
     value: <+input>.allowedValues(true,false)
     default: "false"
-
+  - name: modify_default
+    description: Update the Harness Platform to use the newly pushed images.
+    type: String
+    value: <+input>.allowedValues(true,false)
+    default: "${MODIFY_DEFAULT}"

--- a/harness-ci-factory/variables.tf
+++ b/harness-ci-factory/variables.tf
@@ -86,3 +86,9 @@ variable "schedule" {
   description = "[Optional] Cron Format schedule for when and how frequently to schedule this pipeline"
   default     = "0 2 * * *"
 }
+
+variable "modify_default_image_config" {
+  type        = bool
+  description = "[Optional] Update the Harness Platform to use the newly pushed images as the default versions when running CI pipelines. (requires modification of the harnessImages docker connector)"
+  default     = true
+}


### PR DESCRIPTION
Make changing the default harness image config an optional config. The default is to change it, but you can now skip that step.

This allows you to have a pipeline that just saves the harness images to your own registry, and then you can just set that registry connector as the image override in specific stages.