### PR TITLE
New OPA Policy examples

### DIFF
--- a/opa-examples/pipelines/pipeline_properties/restrict-pipeline-definition-branches.rego
+++ b/opa-examples/pipelines/pipeline_properties/restrict-pipeline-definition-branches.rego
@@ -1,0 +1,20 @@
+# OPA Policy: Restrict Pipeline Definition Branches
+package pipeline
+import future.keywords.in
+
+# Provide allowed branches and regex
+approved_branches := ["development", "release/*"]
+
+###############################################################################
+deny[msg] {
+  branch := input.pipeline.gitConfig.branch
+  count([elem | some elem in approved_branches; glob.match(elem, [], branch)]) == 0
+
+  msg := sprintf("Pipeline source must come from an approved branch schema. The branch '%s' is not allowed based on the approved branches - %s", [branch, approved_branches])
+}
+
+###############################################################################
+
+array_contains(arr, elem) {
+	arr[_] = elem
+}

--- a/opa-examples/training/general/001-how-is-data-evaluated-step-1.rego
+++ b/opa-examples/training/general/001-how-is-data-evaluated-step-1.rego
@@ -1,0 +1,21 @@
+# OPA Policy: 001 - How is data evaluated - Step 1
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #1:
+# This example looks for each stage and then returns a formatted message
+###############################################################################
+allow [msg] {
+	# Gather all the stages in the document
+	stage = input.pipeline.stages[_].stage
+
+	# Foreach match of stage.type, return a message with matching stage identifier.
+	msg = sprintf("This pipeline has a stage called: %s", [stage.identifier])
+}
+###############################################################################
+

--- a/opa-examples/training/general/001-how-is-data-evaluated-step-2.rego
+++ b/opa-examples/training/general/001-how-is-data-evaluated-step-2.rego
@@ -1,0 +1,24 @@
+# OPA Policy: 001 - How is data evaluated - Step 2
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #2:
+# This example looks for each stage and then filters out any stage that isn't of
+# Type == "CI".  Only matching conditions will be returned as a message
+###############################################################################
+allow [msg] {
+	# Gather all the stages in the document
+	stage = input.pipeline.stages[_].stage
+
+	# ... filter out stages to include only a specific type
+	stage.type == "CI"
+
+	# Foreach match of stage.type, return a message with matching stage identifier.
+	msg = sprintf("This Stage is a Continuous Integration (CI) stage: %s", [stage.identifier])
+}
+###############################################################################

--- a/opa-examples/training/general/001-how-is-data-evaluated-step-3.rego
+++ b/opa-examples/training/general/001-how-is-data-evaluated-step-3.rego
@@ -1,0 +1,28 @@
+# OPA Policy: 001 - How is data evaluated - Step 3
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #3:
+# This example looks for each stage and then filters out any stage that isn't of
+# Type == "CI".  In addition, each step is evaluated and returned as part of the
+# message
+###############################################################################
+allow [msg] {
+	# Gather all the stages in the document
+	stage = input.pipeline.stages[_].stage
+
+	# ... filter out stages to include only a specific type
+	stage.type == "CI"
+
+	# Gather all the steps in the currently selected stage
+	step = stage.spec.execution.steps[_].step
+
+	# Foreach match of stage.type, return a message with details about every step.
+	msg = sprintf("This CI Stage (%s) has a step: %s of type: %s", [stage.identifier, step.identifier, step.type])
+}
+###############################################################################

--- a/opa-examples/training/general/001-how-is-data-evaluated-step-4.rego
+++ b/opa-examples/training/general/001-how-is-data-evaluated-step-4.rego
@@ -1,0 +1,45 @@
+# OPA Policy: 001 - How is data evaluated - Step 4
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #4:
+# This example looks for each stage and then filters out any stage that isn't of
+# Type == "CI".  In addition, each step is evaluated against a list of types from
+# the constant `approved_types`. Only matching conditions will be returned as a
+# message
+###############################################################################
+approved_types = [
+	"AquaTrivy",
+	"BlackDuck",
+	"Checkmarx",
+	"Gitleaks",
+	"Nikto",
+	"Owasp",
+	"PrismaCloud",
+	"Prowler",
+	"Snyk",
+	"Zap"
+]
+allow [msg] {
+	# Gather all the stages in the document
+	stage = input.pipeline.stages[_].stage
+
+	# ... filter out stages to include only a specific type
+	stage.type == "CI"
+
+	# Gather all the steps in the currently selected stage
+	step = stage.spec.execution.steps[_].step
+
+	# ... check to see if the step type matches one of the approved types by checkin
+	#	 each element in the list of approved_types
+	approved_types[_] = step.type
+
+	# Foreach match of stage.type and step.type, return a message.
+	msg = sprintf("This CI Stage (%s) has a step: %s of type: %s which is required", [stage.identifier, step.identifier, step.type])
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-1.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-1.rego
@@ -1,0 +1,25 @@
+# OPA Policy: 002 - Enforcing a Stage Policy - Step 1
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #1:
+# This example simply looks for any stage of type Approval
+#
+# The issue with this policy is that it only looks for a single match for an
+# unconditional check.
+#	- What if it is a CI stage?
+#	- What if approval is only required when going to prod?
+###############################################################################
+deny["All deployments require an approval stage"] {
+	not approval_stages
+}
+
+approval_stages {
+	input.pipeline.stages[i].stage.type == "Approval"
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-2.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-2.rego
@@ -1,0 +1,34 @@
+# OPA Policy: 002 - Enforcing a Stage Policy - Step 2
+package pipeline
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #2:
+# This example will only verify the Approval stage exists if there is a Continuous
+# Delivery (CD) stage included
+#
+# The issue with this policy is that it only looks to verify if there is a CD
+# stage.
+#	- What if approval is only required when going to prod?
+#	- What if the approval is -AFTER- the deployment
+#
+###############################################################################
+deny["Every pipeline with a CD stage must include an Approval stage"] {
+	# Verify that there are Deployment stages
+	deployment_stages
+
+	# ... check to see that at least one Approval stage exists
+	not approval_stages
+}
+
+deployment_stages {
+	input.pipeline.stages[i].stage.type == "Deployment"
+}
+approval_stages {
+	input.pipeline.stages[i].stage.type == "Approval"
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-3.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-3.rego
@@ -1,0 +1,57 @@
+# OPA Policy: 002 - Enforcing a Stage Policy - Step 3
+package pipeline
+
+import future.keywords.in
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #3:
+# This example will only verify the Approval stage exists if there is a Continuous
+# Delivery (CD) stage included -AND- that the stage comes -BEFORE- the CD stage.
+#
+# The issue with this policy is that it only looks to verify if there is a CD
+# stage after any Approval stage.
+#	- What if multiple approval stages are used?
+#	- What if there is a requirement that each CD stage must have an immediately
+#	preceeding Approval Stage
+#
+###############################################################################
+
+# Include a special set of keywords to allow for list comprehension
+# -- Note --
+# if using the following as a standalone policy, then please uncomment out the
+# following import statement(s)
+# import future.keywords.in
+
+deny["Every pipeline with a CD stage must include an Approval stage BEFORE the CD Stage"] {
+	# Verify that there are Deployment stages
+	has_deployment_stages
+
+	# ... check to see that at least one Approval stage exists
+	has_approval_stages
+
+	# ... evaluate each stage in the current deployment_stages list
+	some stage in current_deployment_stages
+
+	# ... evaluate the list of current Approval stages to ensure the selected stage proceeds it
+	count([elem | some elem in current_approval_stages; stage > elem]) == 0
+}
+
+has_deployment_stages {
+	input.pipeline.stages[i].stage.type == "Deployment"
+}
+has_approval_stages {
+	input.pipeline.stages[i].stage.type == "Approval"
+}
+
+current_deployment_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Deployment"]
+}
+current_approval_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Approval"]
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-4.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-4.rego
@@ -1,0 +1,55 @@
+# OPA Policy: 002 - Enforcing a Stage Policy - Step 4
+package pipeline
+
+import future.keywords.in
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #4:
+# This example will only verify the Approval stage exists if there is a Continuous
+# Delivery (CD) stage included -AND- that the stage comes -BEFORE- the CD stage.
+#
+# Verbosely handles the checks and returns accurate results
+#	- What if only certain environments require approval stages?
+#
+#
+###############################################################################
+
+# Include a special set of keywords to allow for list comprehension
+# -- Note --
+# if using the following as a standalone policy, then please uncomment out the
+# following import statement(s)
+# import future.keywords.in
+
+deny["Every pipeline with a CD stage must include an Approval stage immediately BEFORE the CD Stage"] {
+	# Verify that there are Deployment stages
+	has_deployment_stages
+
+	# ... check to see that at least one Approval stage exists
+	has_approval_stages
+
+	# ... evaluate each stage in the current deployment_stages list
+	some stage in current_deployment_stages
+
+	# ... evaluate the list of current Approval stages to ensure the selected stage preceeds it
+	count([elem | some elem in current_approval_stages; elem == stage-1]) == 0
+}
+
+has_deployment_stages {
+	input.pipeline.stages[i].stage.type == "Deployment"
+}
+has_approval_stages {
+	input.pipeline.stages[i].stage.type == "Approval"
+}
+
+current_deployment_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Deployment"]
+}
+current_approval_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Approval"]
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-5.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-5.rego
@@ -1,0 +1,62 @@
+# OPA Policy: 002 - Enforcing a Stage Policy - Step 5
+package pipeline
+
+import future.keywords.in
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #5:
+# This example will only verify the Approval stage exists if there is a Continuous
+# Delivery (CD) stage included -AND- that the stage comes -BEFORE- the CD stage and
+# only for named Environment identifiers
+#
+# Verbosely handles the checks and returns accurate results
+#	- What about those complexe pipeline structures?
+#
+###############################################################################
+
+#### BEGIN - Policy Controls ####
+
+approval_required_envs = ["QA", "PROD"]
+
+#### END   - Policy Controls ####
+
+deny["Every pipeline with a CD stage must include an Approval stage immediately BEFORE the CD Stage"] {
+	# Verify that there are Deployment stages
+	has_deployment_stages
+
+	# ... check to see that at least one Approval stage exists
+	has_approval_stages
+
+	# ... evaluate each stage in the current deployment_stages list
+	some stage in current_deployment_stages
+
+	# ... determine if the Environment Identifier matches the approval_required_envs
+	array_contains(approval_required_envs, upper(input.pipeline.stages[stage].stage.spec.environment.environmentRef))
+
+	# ... evaluate the list of current Approval stages to ensure the selected stage preceeds it
+	count([elem | some elem in current_approval_stages; elem == stage-1]) == 0
+}
+
+has_deployment_stages {
+	input.pipeline.stages[i].stage.type == "Deployment"
+}
+has_approval_stages {
+	input.pipeline.stages[i].stage.type == "Approval"
+}
+
+current_deployment_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Deployment"]
+}
+current_approval_stages := output {
+	output := [id | some id, elem in input.pipeline.stages; elem.stage.type == "Approval"]
+}
+
+array_contains(arr, elem) {
+	arr[_] = elem
+}
+###############################################################################

--- a/opa-examples/training/general/002-enforcing-a-stage-policy-step-6.rego
+++ b/opa-examples/training/general/002-enforcing-a-stage-policy-step-6.rego
@@ -1,0 +1,156 @@
+package pipeline
+
+# Include a special set of keywords to allow for list comprehension
+import future.keywords.in
+# Include a special set of keywords to allow for complex conditionals
+import future.keywords.if
+
+###############################################################################
+# Important Note: Each line of a rule is evaluated until the condition returns
+# False or the rule reaches the final line of the section.
+###############################################################################
+
+###############################################################################
+# Example #1:
+# This example will only verify the Approval stage exists if there is a Continuous
+# Delivery (CD) stage included -AND- that the stage comes -BEFORE- the CD stage.
+#
+# Solidly resolves the concerns and validation required to provide consistent results
+#
+###############################################################################
+
+# -- Note --
+# if using the following as a standalone policy, then please uncomment out the
+# following import statement(s)
+# Include a special set of keywords to allow for list comprehension
+# import future.keywords.in
+# Include a special set of keywords to allow for complex conditionals
+# import future.keywords.if
+
+#### BEGIN - Policy Controls ####
+
+approval_required_envs = ["QA", "PROD"]
+
+#### END   - Policy Controls ####
+
+#### BEGIN - Pipeline Step Type Validation ####
+
+# Restrict Forbidden Connectors from being used
+deny[msg] {
+	pipeline_details = return_pipeline_object(input.pipeline)
+	# Verify that there are Deployment stages
+	has_deployment_stages
+
+	# ... check to see that at least one Approval stage exists
+	has_approval_stages
+
+	# ... evaluate each stage to find the next deployment stage
+	resource := [elem | some elem in walk_document(input, "stage")][_]
+
+	stage = object.union(return_stage_object(resource), pipeline_details)
+	stage.details.type == "Deployment"
+
+    # ... determine if the Environment Identifier matches the approval_required_envs
+    array_contains(approval_required_envs, upper(stage.details.spec.environment.environmentRef))
+
+	# ... evaluate the list of current Approval stages to ensure the selected stage preceeds it
+	count([elem | some elem in current_approval_stages; elem == to_number(resource[2])-1]) == 0
+
+	msg = sprintf("Pipeline Stage (%s) does not have an approval stage immediately before the stage - %s", [stage.identifier, resource])
+}
+
+has_deployment_stages {
+	resource := [return_stage_object(elem) | some elem in walk_document(input, "stage")][_]
+	resource.details.type == "Deployment"
+}
+has_approval_stages {
+	resource := [return_stage_object(elem) | some elem in walk_document(input, "stage")][_]
+	resource.details.type == "Approval"
+}
+
+current_approval_stages := output {
+	output := [elem[2] | some elem in walk_document(input, "stage"); return_stage_object(elem).details.type == "Approval"]
+}
+
+#### END   - Pipeline Step Type Validation ####
+
+#### BEGIN - Pipeline Data Normalization ####
+
+# Return a formatted and normalized object of Pipeline details
+return_pipeline_object(elem) := output if {
+	output := {"pipeline": {
+	"identifier": elem.identifier,
+	"name": elem.name,
+	"templateRef": return_template_details(elem)
+	}}
+}
+
+# Return a formatted and normalized object of Step details
+return_stage_object(elem) := output if {
+	stage := return_resources_with_template(elem)
+	output := {
+	"identifier": stage.identifier,
+	"name": stage.name,
+	"templateRef": return_template_details(stage),
+	"details": stage
+	}
+}
+
+#### END   - Pipeline Data Normalization ####
+
+#### BEGIN - Pipeline Evaluation Methods ####
+
+return_template_details(eval_item) := eval_item.template.templateRef if has_key(eval_item, "template") else := "missing"
+
+# This method will return the formatted resource to include the ancestorial template reference into the
+# object only if the step isn't a template.  Otherwise, just return the object details for the resource
+return_resources_with_template(resource) := output if {
+	formatted_resource = return_object_by_notation(resource)
+	not has_key(formatted_resource, "template")
+	templates = walk_document(input, "template")
+	resource_template := [return_object_by_notation(template) | some template in templates; startswith(format_notated_array(resource), format_notated_array(template))]
+	count(resource_template) > 0
+
+	output = object.union(formatted_resource, {"template": resource_template[0]})
+} else := return_object_by_notation(resource)
+
+
+#### END   - Pipeline Evaluation Methods ####
+
+#### BEGIN - Policy Helper Functions ####
+
+# This method will recursively walk the entire document by parsing out each key and compares it against the
+# key type requested.  Upon a pattern match, an array of each path segment is sent back
+walk_document(eval_doc, eval_type) = {final_path |
+	[path, value] := walk(eval_doc)
+	obj_type := path[count(path) - 1]
+	obj_type == eval_type
+
+	value != "REGO requires we use any declared variable so this is a workaround"
+
+	final_path := [elem | some elem in path]
+}
+
+# Collapse a path segment array into an easy to manage dot notation string
+format_notated_array(path) := output if {
+	output := concat(".", [format_notation(elem) | some elem in array.slice(path, 0, count(path) - 1)])
+}
+
+# Rego does not like to combine integers into a string when concatenating.  This will ensure that the
+# number is formatted as a string using a base10 eval
+format_notation(eval_elem) := format_int(eval_elem, 10) if is_number(eval_elem) else := eval_elem
+
+# Query the source document from `input` to search for the value at the provided path.
+# Note: The path variable must be an array of path segments
+return_object_by_notation(path) := object.get(input, path, {})
+
+array_contains(arr, elem) if {
+	arr[_] = elem
+}
+
+has_key(x, k) if {
+	_ = x[k]
+}
+
+#### END   - Policy Helper Functions ####
+###############################################################################


### PR DESCRIPTION
Added new policies design to show the transition of a policy from simple 'Hello World' to more complex structure.  Also added a new policy that allows consumers to restrict GitExp branch selection to only approved branch names or patterns.