### PR TITLE
Terraform resource group with dynamic module

### DIFF
--- a/terraform-resource-group-dynamic-module/README.md
+++ b/terraform-resource-group-dynamic-module/README.md
@@ -1,0 +1,16 @@
+# Overview
+This project aims to demonstrates with sample inputs on how to use dynamic blocks and modules to reuse Resource group to create resource with different permutation and combinations.
+
+## Things to know:
+- [terraform](https://developer.hashicorp.com/terraform]/[opentofu][https://opentofu.org/docs/)
+- terraform [dynamic blocks](https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks)
+- terraform [for_each](https://developer.hashicorp.com/terraform/language/meta-arguments/for_each)
+- terraform [count](https://developer.hashicorp.com/terraform/language/meta-arguments/count)
+
+## Dependencies:
+### Providers
+- harness/harness
+
+## References:
+- [Configuring harness provider in terraform](https://registry.terraform.io/providers/harness/harness/latest/docs).
+- [Harness Terraform Provider quickstart](https://developer.harness.io/docs/platform/automation/terraform/harness-terraform-provider/)

--- a/terraform-resource-group-dynamic-module/main.tf
+++ b/terraform-resource-group-dynamic-module/main.tf
@@ -1,0 +1,23 @@
+resource "harness_platform_organization" "test-org" {
+  name        = var.org_name
+  identifier  = var.org_id
+  description = "Organization created via terraform"
+  tags        = var.org_tag
+}
+
+resource "harness_platform_project" "test-project" {
+  identifier = "testproject"
+  name       = "Test Project"
+  org_id     = resource.harness_platform_organization.test-org.identifier
+}
+
+module "resource_group" {
+  source               = "./module/resource_group"
+  count                = length(var.resource_group)
+  account_id           = var.account_id
+  identifier           = var.resource_group[count.index].identifier
+  name                 = var.resource_group[count.index].name
+  allowed_scope_levels = var.resource_group[count.index].allowed_scope_levels
+  included_scopes      = var.resource_group[count.index].included_scopes
+  resource_filter      = var.resource_group[count.index].resource_filter
+}

--- a/terraform-resource-group-dynamic-module/module/resource_group/main.tf
+++ b/terraform-resource-group-dynamic-module/module/resource_group/main.tf
@@ -1,0 +1,33 @@
+resource "harness_platform_resource_group" "test" {
+  account_id = var.account_id
+  identifier = var.identifier
+  name       = var.name
+
+  allowed_scope_levels = var.allowed_scope_levels
+  dynamic "included_scopes" {
+    for_each = var.included_scopes
+    content {
+      filter     = included_scopes.value.filter
+      account_id = included_scopes.value["account_id"]
+    }
+  }
+  dynamic "resource_filter" {
+    for_each = var.resource_filter
+    content {
+      include_all_resources = resource_filter.value.include_all_resources
+      dynamic "resources" {
+        for_each = resource_filter.value.resources
+        content {
+          resource_type = resources.value.resource_type
+          dynamic "attribute_filter" {
+            for_each = resources.value.attribute_filter
+            content {
+              attribute_name   = attribute_filter.value.attribute_name
+              attribute_values = attribute_filter.value.attribute_values
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-resource-group-dynamic-module/module/resource_group/providers.tf
+++ b/terraform-resource-group-dynamic-module/module/resource_group/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    harness = {
+      source = "harness/harness"
+    }
+  }
+}

--- a/terraform-resource-group-dynamic-module/module/resource_group/variables.tf
+++ b/terraform-resource-group-dynamic-module/module/resource_group/variables.tf
@@ -1,0 +1,40 @@
+variable "account_id" {
+  type        = string
+  description = "Account id"
+}
+variable "identifier" {
+  type        = string
+  description = "identifier"
+}
+
+variable "name" {
+  type        = string
+  description = "name"
+}
+
+variable "allowed_scope_levels" {
+  type        = list(string)
+  description = "Allowed scope levels"
+}
+
+variable "included_scopes" {
+  type = set(object({
+    filter     = string
+    account_id = string
+  }))
+  description = "included scopes"
+}
+
+variable "resource_filter" {
+  type = list(object({
+    include_all_resources = bool
+    resources = set(object({
+      resource_type = string
+      attribute_filter = list(object({
+        attribute_name   = string
+        attribute_values = list(string)
+      }))
+    }))
+  }))
+  description = "resource filter"
+}

--- a/terraform-resource-group-dynamic-module/providers.tf
+++ b/terraform-resource-group-dynamic-module/providers.tf
@@ -6,6 +6,7 @@ terraform {
   }
 }
 
-
+# Using next gen. Auth configured via Env vars (HARNESS_ACCOUNT_ID,HARNESS_ENDPOINT,HARNESS_PLATFORM_API_KEY). 
+# Refer https://registry.terraform.io/providers/harness/harness/latest/docs#optional
 provider "harness" {
 }

--- a/terraform-resource-group-dynamic-module/providers.tf
+++ b/terraform-resource-group-dynamic-module/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    harness = {
+      source  = "harness/harness"
+    }
+  }
+}
+
+
+provider "harness" {
+}

--- a/terraform-resource-group-dynamic-module/values.auto.tfvars
+++ b/terraform-resource-group-dynamic-module/values.auto.tfvars
@@ -1,0 +1,73 @@
+account_id = "<ACCOUNT ID>"
+org_name   = "Sandbox-TF"
+org_id     = "sandboxtf"
+org_tag    = ["type:sandbox", "env:demo"]
+
+resource_group = [
+  {
+    allowed_scope_levels = ["account"]
+    name                 = "resource group 1"
+    identifier           = "resource-group-1"
+    included_scopes = [
+      {
+        filter     = "EXCLUDING_CHILD_SCOPES"
+        account_id = "<ACCOUNT ID>"
+      },
+    ]
+    resource_filter = [
+      {
+        include_all_resources = false
+        resources = [
+          {
+            resource_type = "CONNECTOR"
+            attribute_filter = [
+              {
+                attribute_name   = "category"
+                attribute_values = ["CLOUD_COST"]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    allowed_scope_levels = ["account"]
+    name                 = "resource group2"
+    identifier           = "resource-group-2"
+    included_scopes = [
+      {
+        filter     = "EXCLUDING_CHILD_SCOPES"
+        account_id = "account_id"
+      },
+    ]
+    resource_filter = [
+      {
+        include_all_resources = false
+        resources = [
+          {
+            resource_type    = "CONNECTOR"
+            attribute_filter = []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    allowed_scope_levels = ["account"]
+    name                 = "resource group 3"
+    identifier           = "resource-group-3"
+    included_scopes      = []
+    resource_filter = [
+      {
+        include_all_resources = false
+        resources = [
+          {
+            resource_type    = "CONNECTOR"
+            attribute_filter = []
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/terraform-resource-group-dynamic-module/variables.tf
+++ b/terraform-resource-group-dynamic-module/variables.tf
@@ -1,0 +1,45 @@
+variable "account_id" {
+  type        = string
+  description = "Account ID"
+  default     = ""
+}
+
+variable "org_name" {
+  type        = string
+  description = "org name"
+  default     = ""
+}
+
+variable "org_id" {
+  type        = string
+  description = "org name"
+  default     = ""
+}
+
+variable "org_tag" {
+  type        = list(string)
+  default     = [""]
+  description = "Org tags"
+}
+
+variable "resource_group" {
+  type = list(object({
+    name                 = string
+    identifier           = string
+    allowed_scope_levels = list(string)
+    included_scopes = set(object({
+      filter     = string
+      account_id = string
+    }))
+    resource_filter = list(object({
+      include_all_resources = bool
+      resources = set(object({
+        resource_type = string
+        attribute_filter = list(object({
+          attribute_name   = string
+          attribute_values = list(string)
+        }))
+      }))
+    }))
+  }))
+}


### PR DESCRIPTION
This PR Demonstrates usage of resource group as a module which has dynamic blocks. This can be used to create multiple resource groups with different permutations and combiations.